### PR TITLE
fixed actor tiles size

### DIFF
--- a/src/features/people/ActorTile/styled.js
+++ b/src/features/people/ActorTile/styled.js
@@ -41,10 +41,12 @@ export const ActorName = styled.h3`
   font-weight: 500;
   margin: 12px 0 0 0;
   color: ${({ theme }) => theme.color.woodsmoke};
+  height: 64px;
 
   @media (max-width: ${bpMobile}px) {
     font-size: 14px;
     margin: 8px 0 0 0;
+    height: 36px;
   }
 `;
 

--- a/src/features/people/ActorTile/styled.js
+++ b/src/features/people/ActorTile/styled.js
@@ -11,6 +11,7 @@ export const StyledActorTile = styled(Link)`
   text-decoration: none;
   background-color: ${({ theme }) => theme.color.white};
   transition: all 170ms cubic-bezier(0.45, 0.05, 0.55, 0.95);
+  height: 100%;
 
   &:hover {
     transform: translateY(-4px);
@@ -41,12 +42,10 @@ export const ActorName = styled.h3`
   font-weight: 500;
   margin: 12px 0 0 0;
   color: ${({ theme }) => theme.color.woodsmoke};
-  height: 64px;
 
   @media (max-width: ${bpMobile}px) {
     font-size: 14px;
     margin: 8px 0 0 0;
-    height: 36px;
   }
 `;
 


### PR DESCRIPTION
I noticed a quite serious problem with actor tiles size. Longer names break symmetry on the list. 
![obraz](https://user-images.githubusercontent.com/118211320/222986722-81cabc51-314a-4784-87bb-11445137c384.png)

What you see on this branch is my proposition to fix this problem. 
![obraz](https://user-images.githubusercontent.com/118211320/222986739-42d55214-eed4-4757-86b1-c4042ef63291.png)
